### PR TITLE
Remove duplicate marker

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -12,7 +12,6 @@ const FONTS = {
     'Donegal': require('base64-loader!scratch-render-fonts/DonegalOne-Regular.ttf'),
     'Gloria': require('base64-loader!scratch-render-fonts/GloriaHallelujah.ttf'),
     'Mystery': require('base64-loader!scratch-render-fonts/MysteryQuest-Regular.ttf'),
-    'Marker': require('base64-loader!scratch-render-fonts/PermanentMarker.ttf'),
     'Scratch': require('base64-loader!scratch-render-fonts/Scratch.ttf')
 };
 /* eslint-enable global-require */


### PR DESCRIPTION
Remove the second definition of marker, which incorrectly overwrites the first one. The new marker should automatically start replacing the old one, since they have the same name.

Note that other repos depend/used to depend directly on the github for this repo, so I can't remove the marker font file, which is depended on by some builds out there.