### PR TITLE
Update outstanding dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
     "watch": "webpack --progress --colors --watch"
   },
   "homepage": "https://github.com/LLK/scratch-render-fonts#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/LLK/scratch-render-fonts.git"
-  },
   "dependencies": {
     "base64-loader": "1.0.0"
   },
@@ -32,10 +28,10 @@
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.8.0",
     "json": "^9.0.6",
-    "lodash.defaultsdeep": "4.6.0",
+    "lodash.defaultsdeep": "^4.6.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",
     "webpack": "^4.8.0",
-    "webpack-cli": "^2.0.15"
+    "webpack-cli": "^3.3.10"
   }
 }


### PR DESCRIPTION
This PR:

* Updates `lodash.defaultsdeep` to 4.6.1 to resolve 2 `npm audit` vulnerabilities
* Updates `webpack-cli` to 3.3.10 to allow builds to run again (I ran into this while building #13)
* Removes a duplicated `repository` entry from `package.json`